### PR TITLE
Stages for 1.5.5 release, removes python 3.7 support (EOL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ release.
 -->
 
 ## [Unreleased]
+
+## [1.5.5]()
 ### Fixed
 - Fixed a bug in which read_ipf_str() returned a ValueError [#200](https://github.com/DOI-USGS/plio/issues/200)
 

--- a/code.json
+++ b/code.json
@@ -47,6 +47,49 @@
       "name": "plio",
       "organization": "U.S. Geological Survey",
       "description": "A planetary surface data input/output library written in Python.",
+      "version": "v1.5.5",
+      "status": "Development",
+
+      "permissions": {
+        "usageType": "openSource",
+        "licenses": [
+          {
+            "name": "Public Domain, CC0-1.0",
+            "URL": "https://code.usgs.gov/astrogeology/plio/-/raw/v1.5.3/LICENSE.md"
+          }
+        ]
+      },
+      "homepageURL": "https://plio.readthedocs.io/en/latest/?badge=latest",
+      "downloadURL": "https://code.usgs.gov/astrogeology/plio/-/archive/v1.5.5/plio-v1.5.5.zip",
+      "disclaimerURL": "https://code.usgs.gov/astrogeology/plio/-/raw/v1.5.5/DISCLAIMER.md",
+      "repositoryURL": "https://code.usgs.gov/astrogeology/plio.git",
+      "vcs": "git",
+  
+      "laborHours": 1000,
+  
+      "tags": [
+        "Planetary",
+        "Remote Sensing",
+        "Photogrammetry",
+        "Data Processing"
+      ],
+  
+      "languages": [
+        "python"
+      ],
+  
+      "contact": {
+        "name": "Dr. Jason Laura",
+        "email": "jlaura@usgs.gov"
+      },
+  
+      "date": {
+        "metadataLastUpdated": "2023-09-19"
+      }
+    }, {
+      "name": "plio",
+      "organization": "U.S. Geological Survey",
+      "description": "A planetary surface data input/output library written in Python.",
       "version": "v1.5.3",
       "status": "Development",
 
@@ -59,7 +102,6 @@
           }
         ]
       },
-  
       "homepageURL": "https://plio.readthedocs.io/en/latest/?badge=latest",
       "downloadURL": "https://code.usgs.gov/astrogeology/plio/-/archive/v1.5.3/plio-v1.5.3.zip",
       "disclaimerURL": "https://code.usgs.gov/astrogeology/plio/-/raw/v1.5.3/DISCLAIMER.md",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', 'r') as f:
 def setup_package():
     setup(
         name = "plio",
-        version = '1.5.4',
+        version = '1.5.5',
         author = "USGS Astrogeology",
         author_email = "jlaura@usgs.gov",
         description = ("I/O API to support planetary data formats."),
@@ -38,7 +38,6 @@ def setup_package():
             "Development Status :: 5 - Production/Stable",
             "Topic :: Utilities",
             "License :: Public Domain",
-            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
This PR sets up the release of the recently merged bug and removes support for python3.7 ( EOL for a few months already).

Once merged, someone (can be me) need to create a v1.5.5 tagged release (as per code.json) and then we'll need to merge the PR that lands on conda-forge.