### PR TITLE
Coverage

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
        os: [ubuntu-latest, macos-latest]
-       python-version: ["3.8", "3.9", "3.10", "3.11"]   
+       python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]   
     defaults:
       run:
         shell: bash -l {0}
@@ -42,13 +42,6 @@ jobs:
       - name: Test Python Package
         run: |
            pytest plio --cov-report=xml
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          verbose: true
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
 
   Build-Docs:
     runs-on: ubuntu-latest

--- a/plio/io/isis_serial_number.py
+++ b/plio/io/isis_serial_number.py
@@ -106,7 +106,7 @@ def generate_serial_number(label):
                 serial_entry = search_translation['*']
             if isinstance(serial_entry, datetime.datetime):
                 # PVL returns datetime objects now. Convert these to string and strip trailing zeros on microseconds.
-                serial_entry = serial_entry.strftime('%Y-%m-%dT%H:%M:%SZ%f').rstrip('0')                
+                serial_entry = serial_entry.strftime('%Y-%m-%dT%H:%M:%S.%f').rstrip('0')                
             serial_number.append(serial_entry)
         except:
             pass

--- a/plio/io/isis_serial_number.py
+++ b/plio/io/isis_serial_number.py
@@ -106,7 +106,7 @@ def generate_serial_number(label):
                 serial_entry = search_translation['*']
             if isinstance(serial_entry, datetime.datetime):
                 # PVL returns datetime objects now. Convert these to string and strip trailing zeros on microseconds.
-                serial_entry = serial_entry.strftime('%Y-%m-%dT%H:%M:%S.%f').rstrip('0')                
+                serial_entry = serial_entry.strftime('%Y-%m-%dT%H:%M:%SZ%f').rstrip('0')                
             serial_number.append(serial_entry)
         except:
             pass


### PR DESCRIPTION
This PR removes the broken coverage push to coveralls.io (which is not approved for use anyway), drops Py3.8, and adds CI for Py3.12.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

