### PR TITLE
Fixes broken CI: Removes coverage push, py3.8, added py3.12

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
        os: [ubuntu-latest, macos-latest]
-       python-version: ["3.8", "3.9", "3.10", "3.11"]   
+       python-version: ["3.9", "3.10", "3.11", "3.12"]   
     defaults:
       run:
         shell: bash -l {0}
@@ -42,13 +42,6 @@ jobs:
       - name: Test Python Package
         run: |
            pytest plio --cov-report=xml
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          verbose: true
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
 
   Build-Docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR removes coverage pushes (which are not using an approved cloud service), removes CI for py3.8, and adds CI for Py3.12.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

