### PR TITLE
Pointid prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ release.
 -->
 
 ## [Unreleased]
+### Fixed
+- Fixed a bug in which prefixes and suffixes were not properly prepended/appended to point_id [#213](https://github.com/DOI-USGS/plio/issues/213)
 
 # [1.6.0]()
 

--- a/plio/io/io_controlnetwork.py
+++ b/plio/io/io_controlnetwork.py
@@ -351,6 +351,8 @@ class IsisStore(object):
                 # Un-mangle common attribute names between points and measures
                 df_attr = self.point_field_map.get(attr, attr)
                 if df_attr in g.columns:
+                    if df_attr == 'id':
+                        continue
                     if df_attr == 'pointLog':
                         # Currently pointLog is not supported.
                         warnings.warn('The pointLog field is currently unsupported. Any pointLog data will not be saved.')


### PR DESCRIPTION
Fixes #213 

point_id was being altered (adding prefix/suffix) and then was overwritten by the original value.  This adds logic to prevent it from being overwritten.

<img width="464" alt="Screenshot 2024-12-14 at 11 22 24 AM" src="https://github.com/user-attachments/assets/ab32435a-fd6f-46ff-875d-aed615d7299c" />


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

