### PR TITLE
Refactor package version retrieval to use importlib.metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ release.
 ## [Unreleased]
 ### Fixed
 - Fixed a bug in which prefixes and suffixes were not properly prepended/appended to point_id [#213](https://github.com/DOI-USGS/plio/issues/213)
+- Fixed a deprecation warning by changing to importlib tools for version determination [#218](https://github.com/DOI-USGS/plio/issues/218)
 
 # [1.6.0]()
 

--- a/plio/__init__.py
+++ b/plio/__init__.py
@@ -1,17 +1,15 @@
-from pkg_resources import get_distribution, DistributionNotFound
 import os.path
+from importlib.metadata import PackageNotFoundError, distribution, version
 
 try:
-    _dist = get_distribution('plio')
-    # Normalize case for Windows systems
-    dist_loc = os.path.normcase(_dist.location)
+    dist = distribution("plio")
+    dist_loc = os.path.normcase(dist.locate_file(""))  # Root location of package
     here = os.path.normcase(__file__)
-    if not here.startswith(os.path.join(dist_loc, 'plio')):
-        # not installed, but there is another version that *is*
-        raise DistributionNotFound
-    __version__ = _dist.version
-except DistributionNotFound:
-    __version__ = 'Please install this project with setup.py'
+    if not here.startswith(os.path.join(dist_loc, "plio")):
+        raise PackageNotFoundError
+    __version__ = version("plio")
+except PackageNotFoundError:
+    __version__ = "Please install this project with setup.py"
 
 # Submodule imports
 from . import io


### PR DESCRIPTION
## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

fixes #218 